### PR TITLE
Give a sensible error message when attempting to set an A record without an address(es).

### DIFF
--- a/infoblox.py
+++ b/infoblox.py
@@ -595,6 +595,8 @@ def main():
                 module.fail_json(msg="Either specify `address` or `addresses`, not both")
             addresses = {address}
             del address
+        if not addresses:
+            module.fail_json(msg="Must specify `address` xor `addresses`")
         addresses = set(addresses)
 
         a_records = infoblox.get_a_record(name)


### PR DESCRIPTION
Forgetting the address at the moment leads to a rather confusing exception!