### PR TITLE
Add get next ip by range

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This gem is known to be compatible with Infoblox versions 1.0 through 2.3.  Whil
 - get_network [network]
 - get_ipv6network [network]
 - get_range [start_addr, end_addr]
-- get_next_available_ip [network] 
+- get_next_available_ip [network] | [start_addr, end_addr] 
 - get_host [hostname]
 - add_host [hostname, network]
 - add_ipv6host [hostname, network]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This gem is known to be compatible with Infoblox versions 1.0 through 2.3.  Whil
 ### Actions
 - get_network [network]
 - get_ipv6network [network]
+- get_range [start_addr, end_addr]
 - get_next_available_ip [network] 
 - get_host [hostname]
 - add_host [hostname, network]
@@ -30,7 +31,7 @@ This gem is known to be compatible with Infoblox versions 1.0 through 2.3.  Whil
 - set_a_record [name, address | addresses, ttl=None] (this will change existing records if they exist)
 - delete_a_record [name]
 
-### Playbooke example
+### Playbook example
 ```
 ---
 - hosts: localhost

--- a/infoblox.py
+++ b/infoblox.py
@@ -591,14 +591,18 @@ def main():
             raise Exception("You must specify the option 'network' or 'address'.")
 
     elif action == "get_next_available_ip":
-        result = infoblox.get_network(network)
+    	if network:
+        	result = infoblox.get_network(network)
+	elif start_addr and end_addr:
+		result = infoblox.get_range(start_addr, end_addr)
         if result:
             network_ref = result[0]["_ref"]
             result = infoblox.get_next_available_ip(network_ref)
             if result:
-                module.exit_json(result=result)
+	    	ip = result["ips"][0]
+                module.exit_json(result=ip)
             else:
-                module.fail_json(msg="No vailable IPs in network: %s" % network)
+                module.fail_json(msg="No available IPs in network: %s" % network)
 
     elif action == "reserve_next_available_ip":
         result = infoblox.reserve_next_available_ip(network)


### PR DESCRIPTION
Added the ability to use a Range for get_next_available_ip. I also changed the result of get_next_available_ip to only return result:\<addr\> rather than the old behaviour of result:[ips:\<addr\>]. This should make it easier to use the result inside a playbook.