### PR TITLE
Add host using range

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,17 @@ This gem is known to be compatible with Infoblox versions 1.0 through 2.3.  Whil
 - get_range [start_addr, end_addr]
 - get_next_available_ip [network] | [start_addr, end_addr] 
 - get_host [hostname]
-- add_host [hostname, network]
+- add_host [hostname, network] | [hostname, start_addr, end_addr]
 - add_ipv6host [hostname, network]
 - delete_host [hostname]
 - set_extattr [hostname, attirbule name, attribute value]
 - get_a_record [name]
 - set_a_record [name, address | addresses, ttl=None] (this will change existing records if they exist)
 - delete_a_record [name]
+
+### Networks vs Ranges
+
+get_next_available_ip and add_host can be used in either a Network or a Range on the Infoblox environment. Use the network parameter in the 192.168.1.0/24 or 192.168.1.0 format to reference a Network. Use the start_addr and end_addr parameters in the 192.168.0.1 format to reference a Range.
 
 ### Playbook example
 ```

--- a/infoblox.py
+++ b/infoblox.py
@@ -513,7 +513,7 @@ def main():
             canonical=dict(required=False),
             comment=dict(required=False, default="Object managed by ansible-infoblox module"),
             api_version=dict(required=False, default="1.7.1"),
-            dns_view=dict(required=False, default="Private"),
+            dns_view=dict(required=False, default="default"),
             net_view=dict(required=False, default="default"),
             ttl=dict(required=False)
         ),


### PR DESCRIPTION
- Added the ability to use add_host with a range (not just with a network).
- Changed add_host to use network/range reference for the WAPI call instead of network CIDR.
- Changed the default DNS view to "default" since that is the name of the default view in a fresh Infoblox environment.