### PR TITLE
Fixed an issue with missing mac address on reserve_next_available_ip()

### DIFF
--- a/infoblox.py
+++ b/infoblox.py
@@ -360,7 +360,7 @@ class Infoblox(object):
     # ---------------------------------------------------------------------------
     # reserve_next_available_ip()
     # ---------------------------------------------------------------------------
-    def reserve_next_available_ip(self, network, mac_addr=None,
+    def reserve_next_available_ip(self, network, mac_addr="00:00:00:00:00:00",
                                   comment=None, extattrs=None):
         """
         Reserve ip address via fixedaddress in infoblox by using rest api


### PR DESCRIPTION
Found an issue with the reserve_next_available() function, which throws an exception "MAC address is required when match_client is undefined", but if you specify a blank mac address everything works.

Platform:
Centos 7.4
Ansible 2.4
vNIOS 8.2